### PR TITLE
CLI for cg-brutaltester and manual running

### DIFF
--- a/codeOfKutulu/pom.xml
+++ b/codeOfKutulu/pom.xml
@@ -48,6 +48,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+			<version>1.3.1</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
@@ -61,6 +66,53 @@
 		</dependency>
 	</dependencies>
 
+    <build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<archive>
+						<manifest>
+							<addClasspath>true</addClasspath>
+							<mainClass>com.codingame.gameengine.runner.CommandLineInterface</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>2.4.2</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<transformers>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>com.codingame.gameengine.runner.CommandLineInterface</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 	<!-- copy boss sources to output directories 
 	<build>
 		<plugins>

--- a/codeOfKutulu/src/main/java/com/codingame/gameengine/runner/CommandLineInterface.java
+++ b/codeOfKutulu/src/main/java/com/codingame/gameengine/runner/CommandLineInterface.java
@@ -1,0 +1,119 @@
+package com.codingame.gameengine.runner;
+
+import com.codingame.gameengine.runner.MultiplayerGameRunner;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+
+import com.codingame.gameengine.runner.dto.GameResult;
+import com.google.common.io.Files;
+
+public class CommandLineInterface {
+    static String JOHNNY_PICTURE 	= "https://static.codingame.com/servlet/fileservlet?id=14267188816585&format=ide_menu_avatar";
+	static String NMAHOUDE_PICTURE 	= "https://static.codingame.com/servlet/fileservlet?id=9701936828280&format=ide_menu_avatar";
+	static String EULERSCHE_PICTURE 	= "https://static.codingame.com/servlet/fileservlet?id=16390390383303&format=ide_menu_avatar";
+	static String KUTULU_PICTURE 	= "https://pbs.twimg.com/profile_images/3192634881/a727e18d3434bd5e99e6a39d6329a985.jpeg";
+
+
+	public static void main(String[] args) {
+		try {
+			Options options = new Options();
+
+			options.addOption("h", false, "Print the help")
+			       .addOption("p1", true, "Required. Player 1 command line.")
+			       .addOption("p2", true, "Required. Player 2 command line.")
+			       .addOption("p3", true, "Player 3 command line.")
+			       .addOption("p4", true, "Player 4 command line.")
+			       .addOption("s", false, "Server mode")
+			       .addOption("l", true, "File output for logs")
+			       .addOption("d", false, "Referee initial data");
+
+			CommandLine cmd = new DefaultParser().parse(options, args);
+
+			if (cmd.hasOption("h") || !cmd.hasOption("p1") || !cmd.hasOption("p2")) {
+				new HelpFormatter().printHelp(
+						"-p1 <player1 command line> -p2 <player2 command line> [-s -l <File output for logs>]",
+						options);
+				System.exit(0);
+			}
+
+			//MultiplayerGameRunner runner = new MultiplayerGameRunner();
+	        MultiplayerGameRunner runner = new MultiplayerGameRunner();
+
+			Field getGameResult = GameRunner.class.getDeclaredField("gameResult");
+			getGameResult.setAccessible(true);
+			GameResult result = (GameResult) getGameResult.get(runner);
+
+			if (cmd.hasOption("d")) {
+				result.refereeInput = cmd.getOptionValue("d");
+			}
+
+			int playerCount = 0;
+
+			for (int i = 1; i <= 4; ++i) {
+				if (cmd.hasOption("p" + i)) {
+					runner.addAgent(cmd.getOptionValue("p" + i), "JohnnyYuge " + Integer.toString(i), JOHNNY_PICTURE);
+				//	runner.addAgent(cmd.getOptionValue("p" + i));
+					playerCount += 1;
+				}
+			}
+
+			if (cmd.hasOption("s")) {
+				runner.start();
+			} else {
+				Method initialize = GameRunner.class.getDeclaredMethod("initialize", Properties.class);
+				initialize.setAccessible(true);
+				initialize.invoke(runner, new Properties());
+
+				Method runAgents = GameRunner.class.getDeclaredMethod("runAgents");
+				runAgents.setAccessible(true);
+				runAgents.invoke(runner);
+
+				if (cmd.hasOption("l")) {
+					Method getJSONResult = GameRunner.class.getDeclaredMethod("getJSONResult");
+					getJSONResult.setAccessible(true);
+
+					Files.asCharSink(Paths.get(cmd.getOptionValue("l")).toFile(), Charset.defaultCharset())
+							.write((String) getJSONResult.invoke(runner));
+				}
+
+				for (int i = 0; i < playerCount; ++i) {
+					System.out.println(result.scores.get(i));
+				}
+
+				for (String line : result.uinput) {
+					System.out.println(line);
+				}
+			}
+
+			// We have to clean players process properly
+			Field getPlayers = GameRunner.class.getDeclaredField("players");
+			getPlayers.setAccessible(true);
+			@SuppressWarnings("unchecked")
+			List<Agent> players = (List<Agent>) getPlayers.get(runner);
+
+			if (players != null) {
+				for (Agent player : players) {
+					Field getProcess = CommandLinePlayerAgent.class.getDeclaredField("process");
+					getProcess.setAccessible(true);
+					Process process = (Process) getProcess.get(player);
+
+					process.destroy();
+				}
+			}
+		} catch (Exception e) {
+			System.err.println(e);
+			e.printStackTrace(System.err);
+			System.exit(1);
+		}
+	}
+
+}

--- a/codeOfKutulu/src/main/java/com/codingame/gameengine/runner/CommandLineInterface.java
+++ b/codeOfKutulu/src/main/java/com/codingame/gameengine/runner/CommandLineInterface.java
@@ -1,0 +1,118 @@
+package com.codingame.gameengine.runner;
+
+import com.codingame.gameengine.runner.MultiplayerGameRunner;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+
+import com.codingame.gameengine.runner.dto.GameResult;
+import com.google.common.io.Files;
+
+public class CommandLineInterface {
+    static String JOHNNY_PICTURE 	= "https://static.codingame.com/servlet/fileservlet?id=14267188816585&format=ide_menu_avatar";
+	static String NMAHOUDE_PICTURE 	= "https://static.codingame.com/servlet/fileservlet?id=9701936828280&format=ide_menu_avatar";
+	static String EULERSCHE_PICTURE 	= "https://static.codingame.com/servlet/fileservlet?id=16390390383303&format=ide_menu_avatar";
+	static String KUTULU_PICTURE 	= "https://pbs.twimg.com/profile_images/3192634881/a727e18d3434bd5e99e6a39d6329a985.jpeg";
+
+
+	public static void main(String[] args) {
+		try {
+			Options options = new Options();
+
+			options.addOption("h", false, "Print the help")
+			       .addOption("p1", true, "Required. Player 1 command line.")
+			       .addOption("p2", true, "Required. Player 2 command line.")
+			       .addOption("p3", true, "Player 3 command line.")
+			       .addOption("p4", true, "Player 4 command line.")
+			       .addOption("s", false, "Server mode")
+			       .addOption("l", true, "File output for logs")
+			       .addOption("d", false, "Referee initial data");
+
+			CommandLine cmd = new DefaultParser().parse(options, args);
+
+			if (cmd.hasOption("h") || !cmd.hasOption("p1") || !cmd.hasOption("p2")) {
+				new HelpFormatter().printHelp(
+						"-p1 <player1 command line> -p2 <player2 command line> [-s -l <File output for logs>]",
+						options);
+				System.exit(0);
+			}
+
+	        MultiplayerGameRunner runner = new MultiplayerGameRunner();
+
+			Field getGameResult = GameRunner.class.getDeclaredField("gameResult");
+			getGameResult.setAccessible(true);
+            setupLeague
+			GameResult result = (GameResult) getGameResult.get(runner);
+
+			if (cmd.hasOption("d")) {
+				result.refereeInput = cmd.getOptionValue("d");
+			}
+
+			int playerCount = 0;
+
+			for (int i = 1; i <= 4; ++i) {
+				if (cmd.hasOption("p" + i)) {
+					runner.addAgent(cmd.getOptionValue("p" + i), cmd.getOptionValue("p" + i) + " " + Integer.toString(i), JOHNNY_PICTURE);
+					playerCount += 1;
+				}
+			}
+
+			if (cmd.hasOption("s")) {
+				runner.start();
+			} else {
+				Method initialize = GameRunner.class.getDeclaredMethod("initialize", Properties.class);
+				initialize.setAccessible(true);
+				initialize.invoke(runner, new Properties());
+
+				Method runAgents = GameRunner.class.getDeclaredMethod("runAgents");
+				runAgents.setAccessible(true);
+				runAgents.invoke(runner);
+
+				if (cmd.hasOption("l")) {
+					Method getJSONResult = GameRunner.class.getDeclaredMethod("getJSONResult");
+					getJSONResult.setAccessible(true);
+
+					Files.asCharSink(Paths.get(cmd.getOptionValue("l")).toFile(), Charset.defaultCharset())
+							.write((String) getJSONResult.invoke(runner));
+				}
+
+				for (int i = 0; i < playerCount; ++i) {
+					System.out.println(result.scores.get(i));
+				}
+
+				for (String line : result.uinput) {
+					System.out.println(line);
+				}
+			}
+
+			// We have to clean players process properly
+			Field getPlayers = GameRunner.class.getDeclaredField("players");
+			getPlayers.setAccessible(true);
+			@SuppressWarnings("unchecked")
+			List<Agent> players = (List<Agent>) getPlayers.get(runner);
+
+			if (players != null) {
+				for (Agent player : players) {
+					Field getProcess = CommandLinePlayerAgent.class.getDeclaredField("process");
+					getProcess.setAccessible(true);
+					Process process = (Process) getProcess.get(player);
+
+					process.destroy();
+				}
+			}
+		} catch (Exception e) {
+			System.err.println(e);
+			e.printStackTrace(System.err);
+			System.exit(1);
+		}
+	}
+
+}

--- a/codeOfKutulu/src/test/java/runner/tests/useplan/Player.java
+++ b/codeOfKutulu/src/test/java/runner/tests/useplan/Player.java
@@ -35,7 +35,7 @@ public class Player {
     while (true) {
       int N = scanner.nextInt();
       for (int p = 0; p < N; p++) {
-        int type = scanner.nextInt();
+        String type = scanner.next();
         int index = scanner.nextInt();
         int x = scanner.nextInt();
         int y = scanner.nextInt();


### PR DESCRIPTION
@JohnnyGuye @nmahoude @eulerscheZahl  please take a look. I added command line interface from https://github.com/dreignier/cg-brutaltester and noticed small bug in useplan unittest.

I will try to get that also linked on https://github.com/dreignier/cg-brutaltester referee list. My compiled set of jars for CoK can be found here: https://github.com/fala13/CoK_artifacts

Example command to run a game that can be viewed in a browser:
`java -jar -Dleague.level=5 codeOfKutulu-1.0.jar -p1  "python -u kt.py" -p2 "java -cp . runner.tests.yell.Player" -p3 "java -cp . runner.tests.uselight.Player" -p4 "java -cp . runner.tests.random.Player"  -l ./logs/game1.json -s`

Example command to run with cg-brutaltester: 
`java -jar cg-brutaltester.jar -r "java -jar -Dleague.level=5 codeOfKutulu-1.0.jar" -p1 "python -u kt.py" -p2 "java -cp . runner.tests.yell.Player" -p3 "java -cp . runner.tests.uselight.Player" -p4 "java -cp . runner.tests.random.Player" -t 2 -n 20 -l "./logs/"`
